### PR TITLE
specify the project directory when looking for the config file.

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -117,6 +117,12 @@ def compile (pluginConfig):
     except Exception:
         pass
 
+    # Titanium Studio needs the absolute path to the project
+    try:
+        test = yaml.load(open(os.path.join(pluginConfig['project_dir'], 'images.yaml'), 'r'))
+    except Exception:
+        pass
+
     if test == None:
         raise Exception('images.yaml file not found!')
 


### PR DESCRIPTION
One more small change: when building a project from Titanium Studio, the current directory isn't necessarily the project directory.  Added a check for images.yaml in the project directory as provided by the plugin properties.
