### PR TITLE
Add prefixes and image path wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,14 @@ appicons:
 the YAML file is assumed to be a group name.  Images are rendered to png files
 and are placed in the path specified.
 
-The `append` property is, as one would
-expect, appended to the end of the filename.  The `rename` property will force
-_each_ image to be renamed to the name specified, so it's really only useful
-if you're rendering a single image.
+The `prepend` and `append` properties can be used to prepend or append text
+to the filename. The `rename` property will force _each_ image to be renamed to
+the name specified, so it's really only useful if you're rendering a single image.
 
 Images are assumed to be in an `images` directory in your project directory.
+You can use wildcards (as well as other special characters supported by
+Python's [glob module](https://docs.python.org/3.1/library/glob.html) to specify
+groups of images under a path.
 
 Since Illustrator accepts a 'scaling' property for rendering and not a DPI,
 it is assumed your files were created with a DPI of 72.  If they weren't,

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ icons:
       - path: Resources/images/ipad
         dpi: 82
 
+      - path: Resources/images/android
+        prepend: 'ic_'
+        dpi: 82
+
    images:
       - icons/foo.ai
       - icons/bar.ai
       - icons/baz.ai
-      - icons/foobar.ai
+      - icons/foo[0-9].ai
+      - more_icons/*.ai
 
 androidui:
    backend: illustrator
@@ -90,7 +95,7 @@ the name specified, so it's really only useful if you're rendering a single imag
 
 Images are assumed to be in an `images` directory in your project directory.
 You can use wildcards (as well as other special characters supported by
-Python's [glob module](https://docs.python.org/3.1/library/glob.html) to specify
+Python's [glob module](https://docs.python.org/3.1/library/glob.html)) to specify
 groups of images under a path.
 
 Since Illustrator accepts a 'scaling' property for rendering and not a DPI,

--- a/plugin.py
+++ b/plugin.py
@@ -1,6 +1,6 @@
  #!/usr/bin/env python
 
-import os, subprocess, inspect, yaml, shutil, sys
+import os, subprocess, inspect, yaml, shutil, sys, glob
 
 class ModCheck (object):
     """handles checking of modification times to see if we need to
@@ -139,6 +139,15 @@ def compile (pluginConfig):
             for plugin in desc['plugins']:
                 module = __import__(plugin)
                 plugins.append(module.plugin(desc))
+
+        # Explode image paths
+        replacers = []
+        for line in desc['images']:
+            if '*' in line or '?' in line or '[' in line:
+                replacers.append(line)
+        for line in replacers:
+            desc['images'].remove(line)
+            desc['images'].extend(glob.glob(os.path.join(pluginConfig['project_dir'], 'images', line)))
 
         for outputConfig in desc['output']:
 

--- a/plugin.py
+++ b/plugin.py
@@ -195,6 +195,8 @@ def compile (pluginConfig):
                     basename = os.path.splitext(os.path.basename(sourceImage))[0]
                     if 'append' in outputConfig:
                         basename += outputConfig['append']
+                    if 'prepend' in outputConfig:
+                        basename = outputConfig['prepend'] + basename
                     basename += '.png'
 
                 # compute filename and temp filename


### PR DESCRIPTION
Added the `prepend` property so that you can add prefixes to rendered image filenames, and use glob to interpret wildcards in image lines so that you can specify ranges of images rather than list all of them out.