### PR TITLE
Specify output dimensions in pixels or density-independent pixels with Inkscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,12 @@ You can use wildcards (as well as other special characters supported by
 Python's [glob module](https://docs.python.org/3.1/library/glob.html)) to specify
 groups of images under a path.
 
-Since Illustrator accepts a 'scaling' property for rendering and not a DPI,
+Since Illustrator accepts a `scaling` property for rendering and not a DPI,
 it is assumed your files were created with a DPI of 72.  If they weren't,
-use the 'srcdpi' to specify the source dpi.
+use the `srcdpi` to specify the source dpi.
+
+Inkscape accepts `width` and `height` properties for exact output dimensions.
+These properties override `dpi` - they're mutually exclusive.
 
 If you create `images/Icon.svg` at 57x57 *points* in inkscape, the above group
 called `appicons`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ icons:
 
       - path: Resources/images/android
         prepend: 'ic_'
-        dpi: 82
+        screen-dpi: 480
+        width-dp: 30
+        height-dp: 30
 
    images:
       - icons/foo.ai
@@ -102,7 +104,10 @@ Since Illustrator accepts a `scaling` property for rendering and not a DPI,
 it is assumed your files were created with a DPI of 72.  If they weren't,
 use the `srcdpi` to specify the source dpi.
 
-Inkscape accepts `width` and `height` properties for exact output dimensions.
+Inkscape accepts pixel and density-independent dimension properties.
+To specify output dimensions in pixels, use `width-px` and `height-px`.
+To specify output dimensions in density-independent pixels, use `width-dp`,
+`height-dp`, and `screen-dpi`, where `screen-dpi` is the target device screen DPI.
 These properties override `dpi` - they're mutually exclusive.
 
 If you create `images/Icon.svg` at 57x57 *points* in inkscape, the above group

--- a/plugin.py
+++ b/plugin.py
@@ -38,6 +38,7 @@ def launch (command):
         raise Exception('Command failed, check output')
 
 def dp_to_px (dp, screen_dpi):
+    """Translate density-independent pixels to pixels for a given screen DPI."""
     return int(ceil(dp * (screen_dpi/float(160))))
 
 def illustrator (infile, outfile, outputConfig, pluginConfig):
@@ -67,7 +68,7 @@ def inkscape (infile, outfile, outputConfig, pluginConfig):
     # Use pixel dimension properties (width-px, height-px)
     if {'width-px', 'height-px'} <= set(outputConfig):
 
-        print 'Rendering', infile, 'to', outfile, 'at', str(outputConfig['width-px']), 'x', str(outputConfig['height-px']), 'px with Inkscape.'
+        print 'Rendering', infile, 'to', outfile, 'at', outputConfig['width-px'], 'x', outputConfig['height-px'], 'px with Inkscape.'
         command.extend([
             "-w",
             str(outputConfig['width-px']),
@@ -78,7 +79,7 @@ def inkscape (infile, outfile, outputConfig, pluginConfig):
     # Use density-independent pixel dimension properties (width-dp, height-dp, screen-dpi)
     elif {'width-dp', 'height-dp', 'screen-dpi'} <= set(outputConfig):
 
-        print 'Rendering', infile, 'to', outfile, 'at', str(outputConfig['width-dp']), 'x', str(outputConfig['height-dp']), 'dp for', str(outputConfig['screen-dpi']), 'DPI screen with Inkscape.'
+        print 'Rendering', infile, 'to', outfile, 'at', outputConfig['width-dp'], 'x', outputConfig['height-dp'], 'dp for', outputConfig['screen-dpi'], 'DPI screen with Inkscape.'
         width_px = dp_to_px(outputConfig['width-dp'], outputConfig['screen-dpi'])
         height_px = dp_to_px(outputConfig['height-dp'], outputConfig['screen-dpi'])
         command.extend([

--- a/plugin.py
+++ b/plugin.py
@@ -58,15 +58,36 @@ def illustrator (infile, outfile, outputConfig, pluginConfig):
 
 def inkscape (infile, outfile, outputConfig, pluginConfig):
     """Render an image with inkscape"""
-    print 'Rendering', infile, 'to', outfile, 'at dpi', outputConfig['dpi'], 'with Inkscape.'
-    command = [
-        "inkscape",
-        "-d",
-        str(outputConfig['dpi']),
-        "-e",
-        outfile,
-        infile
-    ]
+    command = ["inkscape"]
+    
+    # Use width and height properties
+    if 'width' in outputConfig and 'height' in outputConfig:
+
+        # Don't allow dpi and width/height to be set
+        if 'dpi' in outputConfig:
+            raise Exception("DPI and dimension properties for Inkscape export are mutually exclusive.") 
+        
+        print 'Rendering', infile, 'to', outfile, 'at', str(outputConfig['width']), 'x', str(outputConfig['height']), 'px with Inkscape.'
+        command.extend([
+            "-w",
+            str(outputConfig['width']),
+            "-h",
+            str(outputConfig['height'])
+        ])
+
+    # Use DPI property
+    elif 'dpi' in outputConfig:
+        print 'Rendering', infile, 'to', outfile, 'at dpi', outputConfig['dpi'], 'with Inkscape.'
+        command.extend([
+            "-d",
+            str(outputConfig['dpi'])
+        ])
+        
+    else:
+        raise Exception("Invalid Inkscape export configuration for " + outfile)
+
+    command.extend(["-e", outfile, infile])
+        
     launch(command)
 
 def checkProps (names, pluginConfig, outputConfig):


### PR DESCRIPTION
These changes let you specify exact output dimensions in pixels or [density-independent pixels](http://developer.android.com/training/multiscreen/screendensities.html) (given a target screen DPI) when rendering with Inkscape.

The added property groups are:
- `width-px` and `height-px`
- `width-dp`, `height-dp`, and `screen-dpi`

I couldn't find a way to do something similar for Illustrator using AppleScript, unfortunately.
